### PR TITLE
Fix Get-HexStringFromByteArray to accept empty arrays

### DIFF
--- a/KeyTabTools.ps1
+++ b/KeyTabTools.ps1
@@ -470,6 +470,7 @@ function Get-HexStringFromByteArray {
 
     param(
         [Parameter(Mandatory=$true, Position=0)]
+        [AllowEmptyCollection()]
         [byte[]]$Data
     )
 $hexString = $null


### PR DESCRIPTION
Add [AllowEmptyCollection()] attribute to allow empty byte arrays. This fixes the failing Pester test for empty array conversion.