### PR TITLE
Fix Publish-Module to use proper directory structure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,8 +51,19 @@ jobs:
 
           Write-Host "Publishing module to PowerShell Gallery..." -ForegroundColor Cyan
 
-          # Publish using the manifest file path
-          Publish-Module -Path ./KeyTabTools.psd1 -NuGetApiKey $env:PSGALLERY_API_KEY -Verbose
+          # Create module directory structure that Publish-Module expects
+          $moduleName = "KeyTabTools"
+          $moduleDir = "./$moduleName"
+
+          New-Item -ItemType Directory -Path $moduleDir -Force | Out-Null
+          Copy-Item -Path "KeyTabTools.psd1" -Destination $moduleDir
+          Copy-Item -Path "KeyTabTools.psm1" -Destination $moduleDir
+          Copy-Item -Path "KeyTabTools.ps1" -Destination $moduleDir
+          Copy-Item -Path "LICENSE" -Destination $moduleDir
+          Copy-Item -Path "README.md" -Destination $moduleDir
+
+          # Publish the module
+          Publish-Module -Path $moduleDir -NuGetApiKey $env:PSGALLERY_API_KEY -Verbose
 
           Write-Host "Module published successfully!" -ForegroundColor Green
 


### PR DESCRIPTION
Publish-Module requires a directory path, not a file path.

Changes:
1. Create a temporary 'KeyTabTools/' directory
2. Copy module files into it:
   - KeyTabTools.psd1 (manifest)
   - KeyTabTools.psm1 (module)
   - KeyTabTools.ps1 (script)
   - LICENSE
   - README.md
3. Publish from the directory: Publish-Module -Path ./KeyTabTools

This creates the proper module structure that PowerShell Gallery expects:
  KeyTabTools/
  ├── KeyTabTools.psd1
  ├── KeyTabTools.psm1
  ├── KeyTabTools.ps1
  ├── LICENSE
  └── README.md

Fixes error: 'The specified path './KeyTabTools.psd1' is not a valid directory.'