### PR TITLE
Bump version to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.1] - 2024-11-14
 
 ### Added
 - **NEW FEATURE**: `Get-KeyTabEntries` function to parse and list entries from existing keytab files
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated README.md with `Get-KeyTabEntries` usage examples
 - Added detailed documentation for parsing keytab files
 - Updated exported functions list in module documentation
+
+### Fixed
+- Test reliability: Explicitly set KVNO values in tests to ensure consistent behavior
 
 ## [1.3.0] - 2024-11-14
 

--- a/KeyTabTools.psd1
+++ b/KeyTabTools.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'KeyTabTools.psm1'
-    ModuleVersion = '1.3.0'
+    ModuleVersion = '1.3.1'
     GUID = '325f7f9a-87be-42ec-ba96-c5e423718284'
     Author = 'waikinw'
     CompanyName = ''


### PR DESCRIPTION
## Added
- **NEW FEATURE**: `Get-KeyTabEntries` function to parse and list entries from existing keytab files
  - Read and analyze keytab file contents
  - Display principal names, encryption types, KVNOs, and timestamps
  - Support for all encryption types (RC4-HMAC, AES128, AES256)
  - Export capabilities for analysis (CSV, filtering, etc.)
  - Comprehensive error handling for corrupt or invalid files
- Added 9 new comprehensive tests for `Get-KeyTabEntries` function
- Added example usage in README.md (Example 8: Listing Keytab Entries)

## Documentation
- Updated README.md with `Get-KeyTabEntries` usage examples
- Added detailed documentation for parsing keytab files
- Updated exported functions list in module documentation

## Fixed
- Test reliability: Explicitly set KVNO values in tests to ensure consistent behavior